### PR TITLE
Show the info-div after it is updated

### DIFF
--- a/snakeviz/static/drawsvg.js
+++ b/snakeviz/static/drawsvg.js
@@ -181,6 +181,7 @@ var apply_mouseover = function apply_mouseover (selection) {
     var thiscolor = d3.rgb('#ff00ff');
     thispath.style('fill', thiscolor.toString());
     sv_update_info_div(d);
+    sv_show_info_div();
   })
   .on('mouseout', function(d, i){
       // reset nodes to their original color


### PR DESCRIPTION
Originally, the `info-div` is shown/hidden when the mouse enters/leaves the visualization container.

This has problem when user's mouse is already inside the container and refresh the page (e.g., update the url for a different file with keyboard, but the mouse stays inside the container). After the page is refreshed, the `info-div` will not be visible until user's mouse leave and re-enter the container, which causes some confusion.

Therefore, I believe it is better to `show` the `info-div` whenever an `update_info_div` is called, and `hide` it only when mouse leaves the container.

Hope that helps.