### PR TITLE
Provides better error messages when file is invalid. Fixes #60.

### DIFF
--- a/snakeviz/cli.py
+++ b/snakeviz/cli.py
@@ -11,6 +11,7 @@ import socket
 import sys
 import threading
 import webbrowser
+from pstats import Stats
 
 try:
     from urllib.parse import quote_plus
@@ -73,6 +74,13 @@ def main(argv=sys.argv[1:]):
     except IOError as e:
         parser.error('the file %s could not be opened: %s'
                      % (filename, str(e)))
+
+    try:
+        Stats(filename)
+    except:
+        parser.error(('the file %s is not a valid profile. ' % filename) +
+                     'Generate profiles using: \n\n'
+                     '\tpython -m cProfile -o my_program.prof my_program.py\n')
 
     filename = quote_plus(filename)
 

--- a/snakeviz/main.py
+++ b/snakeviz/main.py
@@ -24,7 +24,10 @@ settings = {
 class VizHandler(tornado.web.RequestHandler):
     def get(self, profile_name):
         profile_name = unquote_plus(profile_name)
-        s = Stats(profile_name)
+        try:
+            s = Stats(profile_name)
+        except:
+            raise RuntimeError('Could not read %s.' % profile_name)
         self.render(
             'viz.html', profile_name=profile_name,
             table_rows=table_rows(s), callees=json_stats(s))


### PR DESCRIPTION
When snakeviz is run directly on a python .py file, the error message is a parsing error from Stats, which can be confusing. This PR handles that error and suggests the syntax for generating a profile file. 

I believe this is the origin of issue #60. I experienced the same problem. 