### PR TITLE
 Add hint for when snakeviz cli fails and use tox for testing and

### DIFF
--- a/snakeviz/cli.py
+++ b/snakeviz/cli.py
@@ -77,10 +77,15 @@ def main(argv=sys.argv[1:]):
 
     try:
         Stats(filename)
-    except:
+    except Exception as exc:
+        extra_info = ''
+        if isinstance(exc, ValueError):
+            extra_info = 'Hint: Ensure you are running snakeviz using the same Python version as the profile!'
+
         parser.error(('the file %s is not a valid profile. ' % filename) +
                      'Generate profiles using: \n\n'
-                     '\tpython -m cProfile -o my_program.prof my_program.py\n')
+                     '\tpython -m cProfile -o my_program.prof my_program.py\n\n' + extra_info
+        )
 
     filename = quote_plus(filename)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py{26,27,33,34,35}
+
+[testenv]
+deps =
+	pytest
+	requests
+	tornado
+commands = py.test


### PR DESCRIPTION
I kept running into errors when using snakeviz cli as I was generating profiles in a virtual machine/on our production servers using Python 3.5, but then using these profiles to run the snakeviz visualisation on my local machine that was using Python 2.7.   `marshal.loads`  (eventually called through `pstats.Stats.` `__init__`) generates a `ValueError` in these cases.  An extra hint in the `cli.py` error message would be a great sense check. 

Also noticed that this project could use `tox` for easy testing in multiple Python versions rather than just running `py.test`.  Tests (and personal experience) indicates that `snakeviz` works on Python 3.5.  If you are using a `tox.ini` file, then you can also edit the `.travis.yml` file to the following:

```
sudo: false

notifications:
  email: false

language: python
python: 3.5

install:
  - pip install tox

script: tox
```