### PR TITLE
Allow the root node to be changed

### DIFF
--- a/snakeviz/stats.py
+++ b/snakeviz/stats.py
@@ -20,6 +20,7 @@ def table_rows(stats):
     for k, v in stats.stats.items():
         flf = xhtml_escape('{0}:{1}({2})'.format(
             os.path.basename(k[0]), k[1], k[2]))
+        name = '{0}:{1}({2})'.format(*k)
 
         if v[0] == v[1]:
             calls = str(v[0])
@@ -35,7 +36,7 @@ def table_rows(stats):
 
         rows.append(
             [[calls, v[1]], tot_time, tot_time_per,
-             cum_time, cum_time_per, flf])
+             cum_time, cum_time_per, flf, name])
 
     return rows
 

--- a/snakeviz/templates/viz.html
+++ b/snakeviz/templates/viz.html
@@ -100,7 +100,7 @@
       // Make the stats table
       var table_data = {% raw table_rows %};
       $(document).ready(function() {
-        $('#pstats-table').dataTable({
+        var table = $('#pstats-table').dataTable({
           'data': table_data,
           'columns': [
             {'title': 'ncalls', 'type': 'num', 'searchable': 'false',
@@ -116,6 +116,14 @@
           ],
           'order': [1, 'desc'],
           'paging': false
+        }).api();
+        $('#pstats-table tbody').on('click', 'tr', function() {
+          var name = table.row(this).data()[6];
+          sv_root_func_name = name;
+          sv_draw_vis(name);
+          sv_call_stack = [name];
+          sv_update_call_stack_list();
+          d3.select('#resetbutton').property('disabled', 'True');
         });
       });
     </script>


### PR DESCRIPTION
Clicking on a row in the table will make that row become the new root.
This is useful if the default heuristic doesn't find the root you want.
Amongst other reasons, this can happen with multithreaded programs where
the root you really want is a thread that doesn't take the most CPU
time. It could also be handy if you can't immediately find the function
you're interested in on the plot.

I'm not a Javascript expert, so it's quite possible that there are
better ways to do this. This might be too prone to being accidentally
triggered, and possibly the Reset button should go back to the original
root instead of the current root.