### PR TITLE
Allow running snakeviz as `python -m snakeviz.cli`

### DIFF
--- a/snakeviz/cli.py
+++ b/snakeviz/cli.py
@@ -139,3 +139,7 @@ def main(argv=sys.argv[1:]):
         print('\nBye!')
 
     return 0
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This change allows running snakeviz as `python -m snakeviz.cli` for
the benefit of installations where the snakeviz scriptis not in PATH
but python is.