### PR TITLE
List directories to let users browse for pstat files

### DIFF
--- a/snakeviz/cli.py
+++ b/snakeviz/cli.py
@@ -139,3 +139,7 @@ def main(argv=sys.argv[1:]):
         print('\nBye!')
 
     return 0
+
+
+if __name__ == '__main__':
+    main()

--- a/snakeviz/main.py
+++ b/snakeviz/main.py
@@ -24,6 +24,11 @@ settings = {
 class VizHandler(tornado.web.RequestHandler):
     def get(self, profile_name):
         profile_name = unquote_plus(profile_name)
+        abspath = os.path.abspath(profile_name)
+        if os.path.isdir(abspath):
+            if not self.request.path.endswith(os.path.sep):
+                return self.redirect(self.request.path + os.path.sep)
+            return self._list_dir(abspath)
         try:
             s = Stats(profile_name)
         except:
@@ -32,6 +37,21 @@ class VizHandler(tornado.web.RequestHandler):
             'viz.html', profile_name=profile_name,
             table_rows=table_rows(s), callees=json_stats(s))
 
+    def _list_dir(self, path):
+        entries = os.listdir(path)
+        dir_entries = []
+        for name in entries:
+            fullname = os.path.join(path, name)
+            displayname = linkname = name
+            # Append / for directories or @ for symbolic links
+            if os.path.isdir(fullname):
+                displayname = name + "/"
+                linkname = name + "/"
+            if os.path.islink(fullname):
+                displayname = name + "@"
+            dir_entries.append([[displayname, linkname]])
+        self.render(
+            'dir.html', profile_name=path, table_rows=dir_entries)
 
 handlers = [(r'/snakeviz/(.*)', VizHandler)]
 

--- a/snakeviz/main.py
+++ b/snakeviz/main.py
@@ -26,8 +26,8 @@ class VizHandler(tornado.web.RequestHandler):
         profile_name = unquote_plus(profile_name)
         abspath = os.path.abspath(profile_name)
         if os.path.isdir(abspath):
-            if not self.request.path.endswith(os.path.sep):
-                return self.redirect(self.request.path + os.path.sep)
+            if not self.request.path.endswith('/'):
+                return self.redirect(self.request.path + '/')
             return self._list_dir(abspath)
         try:
             s = Stats(profile_name)

--- a/snakeviz/main.py
+++ b/snakeviz/main.py
@@ -39,7 +39,7 @@ class VizHandler(tornado.web.RequestHandler):
 
     def _list_dir(self, path):
         entries = os.listdir(path)
-        dir_entries = []
+        dir_entries = [[['..', '..']]]
         for name in entries:
             fullname = os.path.join(path, name)
             displayname = linkname = name

--- a/snakeviz/templates/dir.html
+++ b/snakeviz/templates/dir.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" .>
+    <title>{{profile_name.split('/')[-1].split('.')[0]}}</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link href="/static/snakeviz.css" rel="stylesheet">
+
+    <!-- DataTables CSS -->
+    <link href="/static/vendor/jquery.dataTables.min.css" rel="stylesheet">
+  </head>
+
+  <body>
+    <h1 id="snakeviz-text">SnakeViz</h1>
+
+    <!-- Entries table -->
+    <div id="table_div">
+      <table cellpadding="0" cellspacing="0" border="0" class="display" id="pstats-table">
+      </table>
+    </div>
+
+    <!-- Le javascript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <!-- Vendor JS -->
+    <script src="/static/vendor/jquery-3.2.1.min.js"></script>
+    <script src="/static/vendor/d3.v3.min.js"></script>
+    <script src="/static/vendor/jquery.dataTables.min.js"></script>
+    <script src="/static/vendor/lodash.min.js"></script>
+    <script src="/static/vendor/immutable.min.js"></script>
+
+    <!-- SnakeViz JS -->
+    <script>
+      // Make the stats table
+      var table_data = {% raw table_rows %};
+      $(document).ready(function() {
+        $('#pstats-table').dataTable({
+          'data': table_data,
+          'columns': [
+            {'title': 'filename',
+             'render': function(data, type, row, meta){
+                 if(type === "display") {
+                    data = '<a href="' + data[1] + '">' + data[0] + '</a>';
+                 }
+                 return data;
+             }}
+          ],
+          'order': [0, 'asc'],
+          'paging': false
+        });
+      });
+    </script>
+
+    <!-- Load SnakeViz JS Files -->
+    <script src='/static/snakeviz.js'></script>
+    <script src='/static/drawsvg.js'></script>
+
+    <!-- Do initial setup stuff -->
+
+  </body>
+</html>


### PR DESCRIPTION
Not sure if its worth any good, but I've added a very simple no-frills file browser to snakeviz.
It is essentially a directory lister, and lists the contents of a directory when a directory is browsed in snakeviz, for example `http://127.0.0.1:8080/snakeviz/` enlists the contents of the directory snakeviz was started from. This punts all issues about security, but I figured out that you can anyway pass on any path to snakeviz via the url so it is apparently not a lot insecure from the current situation.

This is just in case someone wants to use or review, or as a starting point for #1 