### PR TITLE
Add ability to pass multiple profiles which are merged in call to

### DIFF
--- a/snakeviz/main.py
+++ b/snakeviz/main.py
@@ -22,19 +22,21 @@ settings = {
 
 
 class VizHandler(tornado.web.RequestHandler):
-    def get(self, profile_name):
-        profile_name = unquote_plus(profile_name)
+    def get(self, profiles):
+        profiles = unquote_plus(profiles)
+        individual_profiles = profiles.split('&')
 
-        abspath = os.path.abspath(profile_name)
-        if os.path.isdir(abspath):
-            self._list_dir(abspath)
+        # abspath = os.path.abspath(profile_name)  Already absolute from client
+        if len(individual_profiles) == 1 and os.path.isdir(individual_profiles[0]):
+            self._list_dir(individual_profiles[0])
         else:
+            display_name = 'Multiple profiles' if len(individual_profiles)>1 else individual_profiles[0]
             try:
-                s = Stats(profile_name)
-            except:
-                raise RuntimeError('Could not read %s.' % profile_name)
+                s = Stats(*individual_profiles)  # Merge one or more profiles
+            except Exception,e:
+                raise RuntimeError('Error getting stats for %s: %s' % individual_profiles, str(e))
             self.render(
-                'viz.html', profile_name=profile_name,
+                'viz.html', display_name=display_name,
                 table_rows=table_rows(s), callees=json_stats(s))
 
     def _list_dir(self, path):

--- a/snakeviz/templates/viz.html
+++ b/snakeviz/templates/viz.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" .>
-    <title>{{profile_name.split('/')[-1].split('.')[0]}}</title>
+    <title>{{display_name.split('/')[-1].split('.')[0]}}</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 


### PR DESCRIPTION
    pstat.Stats().  This is a common use case when multiple runs generate
    multiple '.prof' files, e.g. snakeviz prog1.*.prof

    When multiple profiles are passed, the "display_name" which is used
    for the browser tab name is changed to "Multiple profiles"

This change allows running snakeviz with multiple profiles.  It simply concatenates the multiple profiles to the URL with a '&' separator, which is a bit of a hack and MAY fail with some browsers if a HUGE number of profiles is passed.   But it works for me with testing on chrome and safari.