### PR TITLE
Allow embedding snakeviz in a Jupyter Notebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - "3.6"
 install:
     - easy_install -U setuptools
-    - pip install requests tornado
+    - pip install requests tornado ipython
     - pip install .
 script:
     - py.test

--- a/snakeviz/ipymagic.py
+++ b/snakeviz/ipymagic.py
@@ -1,8 +1,17 @@
 import subprocess
 import tempfile
 import time
+from IPython.display import display, HTML
+import uuid
+import urllib
 
 __all__ = ['load_ipython_extension']
+
+
+JUPYTER_HTML_TEMPLATE = """
+<iframe id='{uuid}' frameborder=0 seamless width='100%%' height='1000'></iframe>
+<script>$("#{uuid}").attr({{src:"http://"+document.location.hostname+":{port}{path}"}})</script>
+"""
 
 
 def snakeviz_magic(line, cell=None):
@@ -26,8 +35,15 @@ def snakeviz_magic(line, cell=None):
         ip.run_line_magic('prun', line)
 
     # start up a Snakeviz server
-    sv = subprocess.Popen(['snakeviz', filename])
-
+    if _check_ipynb():
+        port = str(_find_free_port())
+        sv = subprocess.Popen(['snakeviz', "-s", "-H", "0.0.0.0", "-p", port, filename])
+        time.sleep(0.5)
+        path = "/snakeviz/%s" % urllib.parse.quote_plus(filename)
+        # data = requests.get(url).content
+        display(HTML(JUPYTER_HTML_TEMPLATE.format(port=port, path=path, uuid=uuid.uuid1())))
+    else:
+        sv = subprocess.Popen(['snakeviz', filename])
     # give time for the Snakeviz page to load then shut down the server
     time.sleep(3)
     sv.terminate()
@@ -36,3 +52,16 @@ def snakeviz_magic(line, cell=None):
 def load_ipython_extension(ipython):
     ipython.register_magic_function(snakeviz_magic, magic_kind='line_cell',
                                     magic_name='snakeviz')
+
+
+def _check_ipynb():
+    cfg = get_ipython().config
+    return "connection_file" in cfg["IPKernelApp"]
+
+
+def _find_free_port():
+    import socket
+    from contextlib import closing
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        return s.getsockname()[1]

--- a/snakeviz/ipymagic.py
+++ b/snakeviz/ipymagic.py
@@ -1,9 +1,11 @@
 import subprocess
 import tempfile
 import time
-from IPython.display import display, HTML
 import uuid
 import urllib
+
+from IPython.core.magic import Magics, magics_class, line_cell_magic
+from IPython.display import display, HTML
 
 __all__ = ['load_ipython_extension']
 
@@ -14,42 +16,69 @@ JUPYTER_HTML_TEMPLATE = """
 """
 
 
-def snakeviz_magic(line, cell=None):
-    """
-    Profile code and display the profile in Snakeviz.
-    Works as a line or cell magic.
+@magics_class
+class SnakevizMagic(Magics):
 
-    """
-    # get location for saved profile
-    filename = tempfile.NamedTemporaryFile().name
+    @line_cell_magic
+    def snakeviz(self, line, cell=None):
+        """
+        Profile code and display the profile in Snakeviz.
+        Works as a line or cell magic.
 
-    # call signature for prun
-    line = '-q -D ' + filename + ' ' + line
+        Usage, in line mode:
+          %snakeviz [options] statement
 
-    # generate the stats file using IPython's prun magic
-    ip = get_ipython()
+        Usage, in cell mode:
+          %%snakeviz [options] [statement]
+          code...
+          code...
 
-    if cell:
-        ip.run_cell_magic('prun', line, cell)
-    else:
-        ip.run_line_magic('prun', line)
+        Options:
 
-    # start up a Snakeviz server
-    if _check_ipynb():
-        sv = open_snakeviz_and_display_in_notebook(filename)
-    else:
-        sv = subprocess.Popen(['snakeviz', filename])
-    # give time for the Snakeviz page to load then shut down the server
-    time.sleep(3)
-    sv.terminate()
+        -e/--embed
+          If running the snakeviz magic in the Jupyter Notebook,
+          use this flag to embed the snakeviz visualization within
+          the notebook instead of trying to open a new tab.
+
+        """
+        # get location for saved profile
+        filename = tempfile.NamedTemporaryFile().name
+
+        # parse options
+        opts, line = self.parse_options(line, 'e', 'embed', posix=False)
+
+        # call signature for prun
+        line = '-q -D ' + filename + ' ' + line
+
+        # generate the stats file using IPython's prun magic
+        ip = get_ipython()
+
+        if cell:
+            ip.run_cell_magic('prun', line, cell)
+        else:
+            ip.run_line_magic('prun', line)
+
+        # start up a Snakeviz server
+        if _check_ipynb() and ('e' in opts or 'embed' in opts):
+            sv = open_snakeviz_and_display_in_notebook(filename)
+        else:
+            sv = subprocess.Popen(['snakeviz', filename])
+        # give time for the Snakeviz page to load then shut down the server
+        time.sleep(3)
+        sv.terminate()
 
 
 def load_ipython_extension(ipython):
-    ipython.register_magic_function(snakeviz_magic, magic_kind='line_cell',
-                                    magic_name='snakeviz')
+    """Called when user runs %load_ext snakeviz"""
+    ipython.register_magics(SnakevizMagic)
 
 
 def _check_ipynb():
+    """
+    Returns True if IPython is running as the backend for a
+    Jupyter Notebook.
+
+    """
     cfg = get_ipython().config
     return "connection_file" in cfg["IPKernelApp"]
 
@@ -69,19 +98,17 @@ def open_snakeviz_and_display_in_notebook(filename):
         import os
         environ = os.environ.copy()
         environ["PYTHONUNBUFFERED"] = "TRUE"
-        sv = subprocess.Popen(['snakeviz', "-s", "-H", "0.0.0.0", "-p", port, filename],
-                              stdout=subprocess.PIPE, universal_newlines=True, env=environ)
-        # import datetime
-        # now = datetime.datetime.now()
+        sv = subprocess.Popen(
+            ['snakeviz', "-s", "-p", port, filename],
+            stdout=subprocess.PIPE, universal_newlines=True, env=environ)
         while True:
             line = sv.stdout.readline()
             if line.strip().startswith("snakeviz web server started"):
                 break
-        # print("wait", (datetime.datetime.now() - now).total_seconds())
         return sv
 
     sv = _start_and_wait_when_ready()
     path = "/snakeviz/%s" % urllib.parse.quote_plus(filename)
-    # data = requests.get(url).content
-    display(HTML(JUPYTER_HTML_TEMPLATE.format(port=port, path=path, uuid=uuid.uuid1())))
+    display(HTML(JUPYTER_HTML_TEMPLATE.format(
+        port=port, path=path, uuid=uuid.uuid1())))
     return sv

--- a/snakeviz/ipymagic.py
+++ b/snakeviz/ipymagic.py
@@ -2,7 +2,11 @@ import subprocess
 import tempfile
 import time
 import uuid
-import urllib
+
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
 
 __all__ = ['load_ipython_extension']
 
@@ -45,6 +49,11 @@ else:
             If running the snakeviz magic in the Jupyter Notebook,
             use this flag to embed the snakeviz visualization within
             the notebook instead of trying to open a new tab.
+
+            Note that this will briefly open a server with host 0.0.0.0,
+            which in some situations may present a slight security risk as
+            0.0.0.0 means that the server will be available on all network
+            interfaces (if they are not blocked by something like a firewall).
 
             """
             # get location for saved profile
@@ -105,7 +114,7 @@ def open_snakeviz_and_display_in_notebook(filename):
         environ = os.environ.copy()
         environ["PYTHONUNBUFFERED"] = "TRUE"
         sv = subprocess.Popen(
-            ['snakeviz', "-s", "-p", port, filename],
+            ['snakeviz', "-s", "-H", "0.0.0.0", "-p", port, filename],
             stdout=subprocess.PIPE, universal_newlines=True, env=environ)
         while True:
             line = sv.stdout.readline()
@@ -114,7 +123,7 @@ def open_snakeviz_and_display_in_notebook(filename):
         return sv
 
     sv = _start_and_wait_when_ready()
-    path = "/snakeviz/%s" % urllib.parse.quote_plus(filename)
+    path = "/snakeviz/%s" % quote(filename, safe='')
     display(HTML(JUPYTER_HTML_TEMPLATE.format(
         port=port, path=path, uuid=uuid.uuid1())))
     return sv

--- a/snakeviz/ipymagic.py
+++ b/snakeviz/ipymagic.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import subprocess
 import tempfile
 import time
@@ -45,10 +47,10 @@ else:
 
             Options:
 
-            -e/--embed
+            -t/--new-tab
             If running the snakeviz magic in the Jupyter Notebook,
-            use this flag to embed the snakeviz visualization within
-            the notebook instead of trying to open a new tab.
+            use this flag to open snakeviz visualization in a new tab
+            instead of embedded within the notebook.
 
             Note that this will briefly open a server with host 0.0.0.0,
             which in some situations may present a slight security risk as
@@ -60,7 +62,7 @@ else:
             filename = tempfile.NamedTemporaryFile().name
 
             # parse options
-            opts, line = self.parse_options(line, 'e', 'embed', posix=False)
+            opts, line = self.parse_options(line, 't', 'new-tab', posix=False)
 
             # call signature for prun
             line = '-q -D ' + filename + ' ' + line
@@ -74,9 +76,11 @@ else:
                 ip.run_line_magic('prun', line)
 
             # start up a Snakeviz server
-            if _check_ipynb() and ('e' in opts or 'embed' in opts):
+            if _check_ipynb() and not ('t' in opts or 'new-tab' in opts):
+                print('Embedding SnakeViz in the notebook...')
                 sv = open_snakeviz_and_display_in_notebook(filename)
             else:
+                print('Opening SnakeViz in a new tab...')
                 sv = subprocess.Popen(['snakeviz', filename])
             # give time for the Snakeviz page to load then shut down the server
             time.sleep(3)


### PR DESCRIPTION
This PR extends #110, which added the ability to embed snakeviz in a Jupyter Notebook. My extensions on top of #110 make the embedding optional via a flag `-e`/`--embed` flag to the `%snakeviz` magic so people can control the behavior.