### PR TITLE
Fix padding of select menu's on Ubuntu 18

### DIFF
--- a/snakeviz/static/snakeviz.css
+++ b/snakeviz/static/snakeviz.css
@@ -65,7 +65,6 @@ select {
   font-family: monospace;
   font-size: 20px;
   background: white;
-  padding: 10px 20px 10px 20px;
 }
 
 #sv-style-label {


### PR DESCRIPTION
Padding of the left-hand side select boxes causes boxes to overlap. Confirmed on firefox 68.0 and Google Chrome 73 on Ubuntu 18 Gnome.

**Before**:
![Screenshot from 2019-09-17 00-00-14](https://user-images.githubusercontent.com/19995695/64999371-76908480-d8df-11e9-8779-05372ec69dce.png)

**After**:
![Screenshot from 2019-09-17 00-01-11](https://user-images.githubusercontent.com/19995695/64999380-7b553880-d8df-11e9-8f72-2fadedfa207a.png)
