### PR TITLE
Reuse TIME-WAIT sockets

### DIFF
--- a/snakeviz/ipymagic.py
+++ b/snakeviz/ipymagic.py
@@ -112,6 +112,12 @@ def open_snakeviz_and_display_in_notebook(filename):
         from contextlib import closing
 
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            # snakeviz frequently gets called many times in a short period.
+            # This line tells the kernel it's okay to reuse TIME-WAIT sockets,
+            # which means snakeviz will use the same socket on successive runs,
+            # which makes life with snakeviz-over-SSH much easier.
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
             # Try a default range of five ports, then use whatever's free.
             ports = list(range(8080, 8085)) + [0]
             for port in ports:


### PR DESCRIPTION
When the snakeviz server process is killed and it closes its TCP connection, the socket hangs around in TIME-WAIT mode for [several minutes](https://knowledgebase.progress.com/articles/Article/Can-the-time-a-socket-spends-in-TIMED-WAIT-state-be-reduced). The point of TIME-WAIT mode is to avoid a final ACK from the _last_ user of a port showing up in front of the _next_ user of the same port and confusing things. But since snakeviz controls both ends of the connection, this isn't really necessary and we can safely reuse a port that's in TIME-WAIT mode. 

The practical effect of this change is that snakeviz uses the same port (say 8080) every time it runs, which makes life with snakeviz-over-SSH a lot easier.

I'd have implemented this rather than the [pick ports in sequence](https://github.com/jiffyclub/snakeviz/pull/125) if I'd understood the problem properly. Sorry!