### PR TITLE
limit accessible paths

### DIFF
--- a/snakeviz/cli.py
+++ b/snakeviz/cli.py
@@ -99,8 +99,6 @@ def main(argv=None):
                          'Note that snakeviz must be run under the same '
                          'version of Python as was used to create the profile.\n')
 
-    filename = quote(filename, safe='')
-
     hostname = args.hostname
     port = args.port
 
@@ -113,6 +111,8 @@ def main(argv=None):
     # the like
     from .main import app
     import tornado.ioloop
+
+    app.set_allowed_paths([filename])
 
     # As seen in IPython:
     # https://github.com/ipython/ipython/blob/8be7f9abd97eafb493817371d70101d28640919c/IPython/html/notebookapp.py
@@ -130,6 +130,7 @@ def main(argv=None):
         print('No available port found.')
         return 1
 
+    filename = quote(filename, safe='')
     url = "http://{0}:{1}/snakeviz/{2}".format(hostname, port, filename)
     print(('snakeviz web server started on %s:%d; enter Ctrl-C to exit' %
            (hostname, port)))

--- a/snakeviz/main.py
+++ b/snakeviz/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import pathlib
 import os.path
 from pstats import Stats
 
@@ -24,6 +25,7 @@ settings = {
 class VizHandler(tornado.web.RequestHandler):
     def get(self, profile_name):
         abspath = os.path.abspath(profile_name)
+        self._check_if_allowed(abspath)
         if os.path.isdir(abspath):
             self._list_dir(abspath)
         else:
@@ -62,10 +64,46 @@ class VizHandler(tornado.web.RequestHandler):
         self.render(
             'dir.html', dir_name=path, dir_entries=dir_entries)
 
+    def _check_if_allowed(self, abspath):
+        """
+        Checks if given file or directory is in allowed paths.
+        """
+        if not self.application._allowed_paths:
+            # No filter set, allow all.
+            return
+        for path in self.application._allowed_paths:
+            try:
+                # If this doesn't raise, abspath is under path.
+                pathlib.Path(abspath).relative_to(path)
+                return
+            except ValueError:
+                continue
+        raise RuntimeError('Path not allowed')
+
+class Application(tornado.web.Application):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._allowed_paths = []
+
+    def set_allowed_paths(self, paths):
+        """
+        Sets what paths are allowed to be retrieved.
+
+        Call this with a list of strings, paths to files or directories that
+        the server is allowed to display. Any directory arguments are treated
+        as allowed prefixes, e.g., passing in ["/home/user/stuff"] will let you
+        list "stuff" and retrieve any files under it.
+
+        If not called, or called with an empty list, any restrictions are removed.
+        """
+        self._allowed_paths = []
+        for path in paths:
+            self._allowed_paths.append(pathlib.Path(path).resolve())
+
 
 handlers = [(r'/snakeviz/(.*)', VizHandler)]
 
-app = tornado.web.Application(handlers, **settings)
+app = Application(handlers, **settings)
 
 if __name__ == '__main__':
     app.listen(8080)


### PR DESCRIPTION
Previously one could browse the whole filesystem on the machine that
`snakeviz` server was running on. Now we limit what can be viewed to the
filename that was passed in on command line.

In the future the CLI could be extended to allow browsing a directory of
profile files.