### PR TITLE
Add inline titles to the stats table columns

### DIFF
--- a/snakeviz/templates/viz.html
+++ b/snakeviz/templates/viz.html
@@ -91,6 +91,16 @@
     <!-- stats table -->
     <div id="table_div">
       <table cellpadding="0" cellspacing="0" border="0" class="display" id="pstats-table">
+        <thead>
+          <tr>
+            <th title="Total number of calls to the function. If there are two numbers, that means the function recursed and the first is the total number of calls and the second is the number of primitive (non-recursive) calls.">ncalls</th>
+            <th title="Total time spent in the function, not including time spent in calls to sub-functions.">tottime</th>
+            <th title="`tottime` divided by `ncalls`">percall</th>
+            <th title="Cumulative time spent in this function and all sub-functions.">cumtime</th>
+            <th title="`cumtime` divided by `ncalls`">percall</th>
+            <th title="File name and line number were the function is defined, and the function’s name.">filename:lineno(function)</th>
+          </tr>
+        </thead>
       </table>
     </div>
 
@@ -117,16 +127,18 @@
         var table = $('#pstats-table').dataTable({
           'data': table_data,
           'columns': [
-            {'title': 'ncalls', 'type': 'num', 'searchable': 'false',
+            // Note: columns are also defined in #pstats-table in HTML above,
+            // this list must line up with that.
+            {'type': 'num', 'searchable': 'false',
              'data': {
               '_': function (row) {return row[0][0];},
               'sort': function (row) {return row[0][1]}
              }},
-            {'title': 'tottime', 'type': 'num', 'searchable': 'false'},
-            {'title': 'percall', 'type': 'num', 'searchable': 'false'},
-            {'title': 'cumtime', 'type': 'num', 'searchable': 'false'},
-            {'title': 'percall', 'type': 'num', 'searchable': 'false'},
-            {'title': 'filename:lineno(function)'}
+            {'type': 'num', 'searchable': 'false'},
+            {'type': 'num', 'searchable': 'false'},
+            {'type': 'num', 'searchable': 'false'},
+            {'type': 'num', 'searchable': 'false'},
+            {}
           ],
           'order': [1, 'desc'],
           'paging': false


### PR DESCRIPTION
This aims to make this table somewhat more accessible to first-time users who may not be familiar with what these names mean in `cProfile` and are likely to be confused by the two "percall" columns.

Descriptions taken from the Stats Table section in the documentation.