### PR TITLE
ensure valid js dictionary when passing dir_entries into dir.html

### DIFF
--- a/snakeviz/main.py
+++ b/snakeviz/main.py
@@ -2,6 +2,7 @@
 
 import os.path
 from pstats import Stats
+import json
 
 try:
     from urllib.parse import quote
@@ -60,7 +61,7 @@ class VizHandler(tornado.web.RequestHandler):
                 [[displayname, quote(os.path.join(path, linkname), safe='')]])
 
         self.render(
-            'dir.html', dir_name=path, dir_entries=dir_entries)
+            'dir.html', dir_name=path, dir_entries=json.dumps(dir_entries))
 
 
 handlers = [(r'/snakeviz/(.*)', VizHandler)]


### PR DESCRIPTION
this was crashing in python2.7 on linux, because several strings were prepended with a u when dumping them in the template
by using json, this will ensure valid js strings