### PR TITLE
Tweak formatting so that more nodes have text visible in them

### DIFF
--- a/snakeviz/static/drawsvg.js
+++ b/snakeviz/static/drawsvg.js
@@ -282,16 +282,23 @@ var drawIcicle = function drawIcicle(json) {
         .attr("width", function(d) { return x(d.dx); })
         .attr("height", function(d) { return y(d.dy); })
         .attr("font-family", "sans-serif")
-        .attr("font-size", "15px")
+        .attr("font-size", "12px")
         .attr("fill", "black")
         .attr("text-anchor", "middle")
         .attr("pointer-events", "none");
 
-  // Append the function name
+  // Append the function location
   labels.append("tspan")
-    .text(function(d) { return d.display_name; })
+    .text(function(d) { return d.display_name.split("(")[0]; })
     .attr("text-anchor", "middle")
-    .attr("x", function(d) { return x(d.x + (d.dx / 2.0)); });
+    .attr("x", function(d) { return x(d.x + (d.dx / 2.0)); })
+    .attr("dy", "-0.8em");
+  // Append the function name (without wrapping parens to save on width)
+  labels.append("tspan")
+    .text(function(d) { return d.display_name.split("(")[1].slice(0, -1); })
+    .attr("text-anchor", "middle")
+    .attr("x", function(d) { return x(d.x + (d.dx / 2.0)); })
+    .attr("dy", "1.2em");
   // Append the time
   labels.append("tspan")
     .text(function(d) { return d.cumulative.toPrecision(3) + " s"; })


### PR DESCRIPTION
This commit makes node text a bit smaller, with information spread across three lines rather than two. Intent being to reduce the number of empty/blank rectangles displayed.

An example subsection of what it looks likes for a few nodes is here:

![image](https://user-images.githubusercontent.com/2751728/85164346-3bd2c880-b232-11ea-9692-9e892600ebd8.png)

Previously the second node would have been blank (and so would many more in the full chart).

----
More detail...

Prior to this commit, text displayed in the node was quite wide, causing a large number of nodes to be blank (forcing use of hover text).

This commit makes more nodes have text by doing the following:

1. uses a smaller font by default for nodes
2. splits node info across 3 lines instead of 2
    * function location and name are split into two lines (with parens removed)
3. tweaks text offsets to maintain vertical centering of text in the node

These tweaks still fit perfectly when rendering 20 deep.

**_NOTE_**: This could probably have been done earlier in the code (rather than cutting up `display_name` while generating the svg), but the end result is effective and this was quick to do. :)