### PR TITLE
Showing time instead of cumulative in the icicle boxes

### DIFF
--- a/snakeviz/static/drawsvg.js
+++ b/snakeviz/static/drawsvg.js
@@ -294,7 +294,7 @@ var drawIcicle = function drawIcicle(json) {
     .attr("x", function(d) { return x(d.x + (d.dx / 2.0)); });
   // Append the time
   labels.append("tspan")
-    .text(function(d) { return d.cumulative.toPrecision(3) + " s"; })
+    .text(function(d) { return d.time.toPrecision(3) + " s"; })
     .attr("text-anchor", "middle")
     .attr("x", function(d) { return x(d.x + (d.dx / 2.0)); })
     .attr("dy", "1.2em");


### PR DESCRIPTION
I find it very confusing that the size of the boxes and the number of the boxes do not correlate. This fixes it.