### PR TITLE
Fixing typo in documentation

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -50,7 +50,7 @@ Then use the `%snakeviz` (for a single line of code) and
 individual lines or entire blocks of code:
 
 ```
-% snakeviz glob.glob('*.txt')
+%snakeviz glob.glob('*.txt')
 ```
 
 ```


### PR DESCRIPTION
Copy and pasting it from the documentation before this change, I get:

UsageError: Line magic function `%` not found.
