### PR TITLE
Documentation for docker

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -273,6 +273,9 @@ but can speed up the building and rendering of the visualization.
   there when called by a specific caller.
   [This issue](https://github.com/jiffyclub/snakeviz/issues/112) details
   this limitation.
+- To use SnakeViz inside a docker container you will need to expose
+  the ports 8080:8085 from the container to your host. This allows the host web
+  browser to see the container SnakeViz server.  
 
 ## Contact
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -273,7 +273,7 @@ but can speed up the building and rendering of the visualization.
   there when called by a specific caller.
   [This issue](https://github.com/jiffyclub/snakeviz/issues/112) details
   this limitation.
-- To use SnakeViz inside a docker container you will need to expose
+- To use SnakeViz inside a `docker` container you will need to expose
   the ports 8080:8085 from the container to your host. This allows the host web
   browser to see the container SnakeViz server.  
 


### PR DESCRIPTION
I have added a short description of how to get SnakeViz working inside a docker container. If you don't expose the correct ports SnakeViz will get a connection error. 

I assume only ports 8080:8085 are possible for SnakeViz to use? Does this mean you are limited to a maximum of 5 cells that can be profiled? It might be worthwhile noting this somewhere.

Thanks