### PR TITLE
Adds support for Jupyter instances running remotely, also adds new parameter for visualizing existing profiling result

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
                      'static/images/*.png',
                      'templates/*.html']
     },
-    install_requires=['tornado>=2.0'],
+    install_requires=['tornado>=2.0', 'requests>=2.25.1'],
     entry_points={
         'console_scripts': ['snakeviz = snakeviz.cli:main']
     }


### PR DESCRIPTION
The tornado server was not reachable when user ran Jupyter remotely (e.g. on a server with SSH tunnelling). Now the HTML is retrieved from tornado on the server side (hence requests lib dependency) and loaded into iframe.

Also added support for reusing an already existing profiling results with the -p parameter in the magics.