### PR TITLE
Speedup icicle chart up to 10x, by using a faster label removal method

### DIFF
--- a/snakeviz/static/drawsvg.js
+++ b/snakeviz/static/drawsvg.js
@@ -301,13 +301,8 @@ var drawIcicle = function drawIcicle(json) {
 
   // Remove labels that don't fit
   d3.selectAll("text")
-    .each(function(d, a, b) {
-      // var text = d3.selectd(this);
-      var bbox = this.getBBox();
-      if (bbox.width > x(d.dx)) {
-        this.remove();
-      }
-    });
+    .filter(function(d) { return this.getBBox().width > x(d.dx); })
+    .remove();
 };
 
 // Clear and redraw the visualization


### PR DESCRIPTION
Love snakeviz! It is a bit annoying that the icicle chart can take a while, especially when there's a lot of elements

The current method to remove labels is slow. I'm no d3 expert, but I think that's because it's in a loop and not using built-in d3 methods. If we just remove labels via a d3 filter I'm noticing a particular icicle chart going from 20 seconds (on master) to render to 2 seconds (on this branch).