### PR TITLE
Make dropdowns more consistent looking

### DIFF
--- a/snakeviz/static/snakeviz.css
+++ b/snakeviz/static/snakeviz.css
@@ -65,7 +65,7 @@ select {
   font-family: monospace;
   font-size: 20px;
   background: white;
-  padding: 10px 20px 10px 20px;
+  padding: 5px 10px 5px 10px;
 }
 
 #sv-style-label {

--- a/snakeviz/templates/viz.html
+++ b/snakeviz/templates/viz.html
@@ -28,7 +28,7 @@
     </span>
 
     <!-- style select -->
-    <label id='sv-style-label'>Style:
+    <label id='sv-style-label'>Style:&nbsp;
       <select name="sv-style" id="sv-style-select">
         <option value="icicle" selected>Icicle</option>
         <option value="sunburst">Sunburst</option>
@@ -36,7 +36,7 @@
     </label>
 
     <!-- depth select -->
-    <label id='sv-depth-label'>Depth:
+    <label id='sv-depth-label'>Depth:&nbsp;
       <select name="sv-depth" id="sv-depth-select">
         {% for i in [3, 5, 10, 15, 20] %}
           <option value="{{i}}" {% if i == 10 %}selected{% end %}>{{i}}</option>


### PR DESCRIPTION
This should line up the dropdowns better!

**Before:**

<img width="429" alt="Screen Shot 2021-09-07 at 11 53 17 PM" src="https://user-images.githubusercontent.com/3710083/132444045-5ee79b67-73b4-46da-b0fa-97258708d0a4.png">

**After:**

<img width="401" alt="Screen Shot 2021-09-07 at 11 52 53 PM" src="https://user-images.githubusercontent.com/3710083/132444058-4d711fac-ffce-4d25-9290-988e45c0e2d3.png">

