### PR TITLE
Configure host and port in ipython magic

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -72,6 +72,19 @@ Note: Using the IPython `%snakeviz` magics requires internet access.
 If you are working offline, use [prun][] to save a profile file
 and then start SnakeViz from the command line.
 
+The snakeviz server that is set up can also be configured for
+remote access. You can configure the host and port of this 
+server using
+
+```python
+%snakeviz_config -h localhost -p 8900
+```
+
+A use for this is in running Jupyter in one server, but 
+browsing to this from another location. Typically, one does this 
+by port forwarding using ssh, in this case one can forward the
+specified port to enable snakeviz in the browser.
+
 ## Generating Profiles
 
 ### cProfile

--- a/snakeviz/__init__.py
+++ b/snakeviz/__init__.py
@@ -1,6 +1,2 @@
-import os
-
-with open(os.path.join('snakeviz', 'version.py'), 'w') as f:
-    f.write('__version__ = version = %r' % "2.2")
 from .version import __version__
 from .ipymagic import *

--- a/snakeviz/__init__.py
+++ b/snakeviz/__init__.py
@@ -1,2 +1,6 @@
+import os
+
+with open(os.path.join('snakeviz', 'version.py'), 'w') as f:
+    f.write('__version__ = version = %r' % "2.2")
 from .version import __version__
 from .ipymagic import *

--- a/tests/test_ipymagic.py
+++ b/tests/test_ipymagic.py
@@ -1,0 +1,52 @@
+
+import IPython.testing.globalipapp as testing
+import IPython.core.error as error
+
+import pytest
+import unittest.mock as mock
+
+import snakeviz.ipymagic
+
+
+@pytest.fixture(scope="module")
+def shell():
+    result = testing.get_ipython()
+    result.run_line_magic("load_ext", "snakeviz")
+    return result
+
+def test_snakeviz_magic_browser_default(shell):
+    # Since we use the test shell we need to make sure we try to embed the display by
+    # faking that we have an interactive shell:
+    with mock.patch.object(snakeviz.ipymagic, "_check_ipynb", return_value=True):
+
+        with mock.patch.object(snakeviz.ipymagic, "display") as mock_display:
+            shell.run_line_magic("snakeviz", "print()")
+            assert mock_display.called
+            html = mock_display.call_args.args[0]._repr_html_()
+            assert "\" + document.location.hostname + \"" in html
+
+
+@pytest.mark.parametrize("config_str,test_str",
+    (
+        ("-h localhost", "localhost"),
+        ("-p 8900", "8900"),
+         ("--host=localhost", "localhost"),
+         ("--port=8900", "8900"),
+         ("-h localhost -p 8900", "localhost:8900"),
+    )
+)
+def test_snakeviz_config(config_str, test_str, shell):
+    shell.run_line_magic("snakeviz_config", config_str)
+    # Since we use the test shell we need to make sure we try to embed the display by
+    # faking that we have an interactive shell:
+    with mock.patch.object(snakeviz.ipymagic, "_check_ipynb", return_value=True):
+        with mock.patch.object(snakeviz.ipymagic, "display") as mock_display:
+            shell.run_line_magic("snakeviz", "print()")
+            assert mock_display.called
+            html = mock_display.call_args.args[0]._repr_html_()
+            assert test_str in html
+
+
+def test_snakeviz_config_unsupported_option(shell):
+    with pytest.raises(error.UsageError, match="option -r not recognized"):
+        shell.run_line_magic("snakeviz_config", "-r")


### PR DESCRIPTION
This adds the ability to set the host and port that is used to access the snakeviz server when running the snakeviz IPython magic.

Currently the browser identifies the server using `document.location.hostname` and a free port in a defined range (or any available free port if the range fails to have any free).   There are services, however, that allow one to run a jupyter notebook as a backend, but connect through the service.  An example of this is Colab.  In this case `document.location.hostname` points to a server different than the one where the jupyter notebook backend is being run.  Further one often wants to select a specific port for access, in particular if one needs to use port forwarding to remotely connect.

This PR solves this problem by allowing one to override the host address and the port.  The host address is not used for the address of the snakeviz server (which is still 0.0.0.0 which becomes 127.0.0.1), but is used for the location of the source that is embedded in the result cell.  The port is used when starting up the snakeviz server, and also used along with the host for the location of the source.  

The host and port are set by a new line magic: `%snakeviz_config`.  This config takes two options, `-h` and `-p` (or their long forms) for setting these options.  

For example if one is running the colab backend locally, using `%snakeviz_config -h localhost` makes the snakeviz magics work.  If one needs to set the port, for example if running a backend on a server, but accessing via port forwards, then one can also specify the port.

Also adds a few tests for the ipython magic.