### PR TITLE
ci: Add Python 3.11 to testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
         include:
           - os: macos-latest
             python-version: "3.7"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: macos-latest
             python-version: "3.7"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development'
     ],
     packages=['snakeviz'],


### PR DESCRIPTION
This PR removes Python 3 releases that are EOL and no longer supported for testing in GitHub Actions from the testing matrix and adds Python 3.11.

For reference:

```console
$ pipx install norwegianblue
$ eol python
┌───────┬────────────┬────────┬────────────────┬────────────┐
│ cycle │  release   │ latest │ latest release │    eol     │
├───────┼────────────┼────────┼────────────────┼────────────┤
│ 3.11  │ 2022-10-24 │ 3.11.1 │   2022-12-06   │ 2027-10-24 │
│ 3.10  │ 2021-10-04 │ 3.10.9 │   2022-12-06   │ 2026-10-04 │
│ 3.9   │ 2020-10-05 │ 3.9.16 │   2022-12-06   │ 2025-10-05 │
│ 3.8   │ 2019-10-14 │ 3.8.16 │   2022-12-06   │ 2024-10-14 │
│ 3.7   │ 2018-06-26 │ 3.7.16 │   2022-12-06   │ 2023-06-27 │
│ 3.6   │ 2016-12-22 │ 3.6.15 │   2021-09-03   │ 2021-12-23 │
│ 3.5   │ 2015-09-12 │ 3.5.10 │   2020-09-05   │ 2020-09-13 │
│ 3.4   │ 2014-03-15 │ 3.4.10 │   2019-03-18   │ 2019-03-18 │
│ 3.3   │ 2012-09-29 │ 3.3.7  │   2017-09-19   │ 2017-09-29 │
│ 2.7   │ 2010-07-03 │ 2.7.18 │   2020-04-19   │ 2020-01-01 │
│ 2.6   │ 2008-10-01 │ 2.6.9  │   2013-10-29   │ 2013-10-29 │
└───────┴────────────┴────────┴────────────────┴────────────┘
```
