### PR TITLE
build: Remove setup.cfg as wheels are Python 3.7+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
Remove the vestigial setup.cfg as with `requires-python = ">=3.7"` in 219a93a6c19c9f31bf53ccd71fa42cfdef3bb773 the wheels are Python 3.7+ and so there is no longer a Python 2 wheel and so no need to mark anything as 'universal'.