### PR TITLE
docs: Note that SnakeViz is Python 3.7+

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,10 +4,9 @@ SnakeViz is a browser based graphical viewer for the output of Python's
 [cProfile][] module and an alternative to using the standard library
 [pstats module][pstats].
 It was originally inspired by [RunSnakeRun][].
-SnakeViz works on Python 2.7 and Python 3.
-SnakeViz itself is still likely to work on Python 2.6,
-but official support has been dropped now that [Tornado][] no longer
-supports Python 2.6.
+SnakeViz works on Python 3.7+.
+SnakeViz v2.1.2 and older are still likely to work on Python 2.7,
+but official support has been dropped now Python 2 is EOL.
 
 ## Installation
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -13,7 +13,7 @@ but official support has been dropped now Python 2 is EOL.
 SnakeViz is available [on PyPI][pypi]. Install with [pip][]:
 
 ```
-pip install snakeviz
+python -m pip install snakeviz
 ```
 
 ## Starting SnakeViz


### PR DESCRIPTION
* Note that SnakeViz is supported on Python 3.7+.
* Note the last version of SnakeViz to support Python 2 is [v2.1.2](https://pypi.org/project/snakeviz/2.1.2/).
* Note that Python 2 is EOL.

I also stuck in an opinion here of

* Advocate for `python -m pip` pattern which is the only way to be truly sure that the `pip` being used is the `pip` for the Python runtime you want.