### PR TITLE
Add support for Python 3.13 and drop EOL 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
             python-version: "3.8"
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.13"
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.9"
           - os: macos-latest
             python-version: "3.13"
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,7 +4,7 @@ SnakeViz is a browser based graphical viewer for the output of Python's
 [cProfile][] module and an alternative to using the standard library
 [pstats module][pstats].
 It was originally inspired by [RunSnakeRun][].
-SnakeViz works on Python 3.8+.
+SnakeViz works on Python 3.9+.
 SnakeViz v2.1.2 and older are still likely to work on Python 2.7,
 but official support has been dropped now Python 2 is EOL.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A web-based viewer for Python profiler output"
 readme = "README.rst"
 license = { file = "LICENSE.txt" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["tornado>=2.0"]
 dynamic = ["version"]
 classifiers = [
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: JavaScript",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development"
 ]
 

--- a/snakeviz/cli.py
+++ b/snakeviz/cli.py
@@ -102,12 +102,6 @@ def main(argv=None):
         parser.error('invalid port number %d: use a port between 0 and 65535'
                      % port)
 
-    # Before starting tornado set the eventloop policy for windows and python 3.8 compatibility
-    # https://github.com/tornadoweb/tornado/issues/2608
-    if sys.platform == 'win32' and sys.version_info[:2] == (3, 8):
-        import asyncio
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     # Go ahead and import the tornado app and start it; we do an inline import
     # here to avoid the extra overhead when just running the cli for --help and
     # the like


### PR DESCRIPTION
Follow on from https://github.com/jiffyclub/snakeviz/pull/195.

Python 3.13 was released in October 2024, at the same time Python 3.8 reached end-of-life:

https://devguide.python.org/versions/

