### PR TITLE
Drop support for end-of-life Python 3.9, and test support for Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.10"
           - os: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,7 +4,7 @@ SnakeViz is a browser based graphical viewer for the output of Python's
 [cProfile][] module and an alternative to using the standard library
 [pstats module][pstats].
 It was originally inspired by [RunSnakeRun][].
-SnakeViz works on Python 3.9+.
+SnakeViz works on Python 3.10+.
 SnakeViz v2.1.2 and older are still likely to work on Python 2.7,
 but official support has been dropped now Python 2 is EOL.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A web-based viewer for Python profiler output"
 readme = "README.rst"
 license = { file = "LICENSE.txt" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["tornado>=2.0"]
 dynamic = ["version"]
 classifiers = [
@@ -19,11 +19,11 @@ classifiers = [
     "Programming Language :: JavaScript",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development"
 ]
 


### PR DESCRIPTION
Python 3.9 reached end-of-life on 2025-10-31: https://peps.python.org/pep-0596/
Python 3.14.0 was released on 2025-10-07: https://peps.python.org/pep-0745/